### PR TITLE
Fixed link to show less on assignments #279

### DIFF
--- a/galah/web/templates/assignments.html
+++ b/galah/web/templates/assignments.html
@@ -35,7 +35,7 @@
         </a>
     {% endif %}
     {% if hidden_assignments < 0 %}
-	<a class="show_hidden heading" href="#">
+	<a class="show_hidden heading" href="/assignments">
             Showing All Assignments (Show Less)
         </a>
     {% endif %}


### PR DESCRIPTION
It was linking to '#', which would've been fine except there's a weird url variable that makes it think it's a different page than the assignments page. I set it to go back to '/assignments' when they click show less. 
